### PR TITLE
Fix readline compilation to work on other distros

### DIFF
--- a/22-Static-Analysis-1.sh
+++ b/22-Static-Analysis-1.sh
@@ -13,6 +13,6 @@ cppcheck --enable=warning,style,performance,portability \
     --error-exitcode=1 \
     "${TEST_DIR}/../" || test_end 1
 
-cc -Wall -Werror -lm -lreadline "${TEST_DIR}"/../{*.c,*.h} || test_end 1
+cc -Wall -Werror "${TEST_DIR}"/../{*.c,*.h} -lm -lreadline || test_end 1
 
 test_end


### PR DESCRIPTION
lib readline will not compile properly on Ubuntu versions 18.04+ if it is not included at the end of the gcc line.